### PR TITLE
그라파나 컨테이너 설정

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -58,6 +58,8 @@ services:
     image: grafana/grafana
     restart: always
     container_name: grafana
+    volumes:
+      - grafana_data:/var/lib/grafana
     ports:
       - '3000:3000'
 
@@ -68,3 +70,4 @@ networks:
 
 volumes:
   data:
+  grafana_data:

--- a/compose.yaml
+++ b/compose.yaml
@@ -54,6 +54,12 @@ services:
       - '9090:9090'
     networks:
       - bside-network
+  grafana:
+    image: grafana/grafana
+    restart: always
+    container_name: grafana
+    ports:
+      - '3000:3000'
 
 networks:
   bside-network:


### PR DESCRIPTION
- 배포 서버에 그라파나 컨테이너 띄우면 docker cp 명령어로 대시보드를 그라파나 볼륨에 마운트할 예정입니다.
    - 대시보드 데이터는 NCP 서버로 옮겨놨습니다. 