### PR TITLE
리포트 상태 조회 기능 구현

### DIFF
--- a/src/main/java/bsise/server/letter/Letter.java
+++ b/src/main/java/bsise/server/letter/Letter.java
@@ -38,6 +38,7 @@ public class Letter extends BaseTimeEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
+    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "daily_report_id")
     private DailyReport dailyReport;

--- a/src/main/java/bsise/server/report/DailyReport.java
+++ b/src/main/java/bsise/server/report/DailyReport.java
@@ -18,6 +18,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
 @Entity
@@ -30,6 +31,7 @@ public class DailyReport extends BaseTimeEntity {
     @Column(name = "daily_report_id", columnDefinition = "BINARY(16)")
     private UUID id;
 
+    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "weekly_report_id")
     private WeeklyReport weeklyReport;

--- a/src/main/java/bsise/server/report/daily/DailyReportRepository.java
+++ b/src/main/java/bsise/server/report/daily/DailyReportRepository.java
@@ -1,0 +1,10 @@
+package bsise.server.report.daily;
+
+import bsise.server.report.DailyReport;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DailyReportRepository extends JpaRepository<DailyReport, UUID> {
+}

--- a/src/main/java/bsise/server/report/retrieve/ReportStatusRetrieveController.java
+++ b/src/main/java/bsise/server/report/retrieve/ReportStatusRetrieveController.java
@@ -1,0 +1,41 @@
+package bsise.server.report.retrieve;
+
+import bsise.server.report.retrieve.dto.DailyReportStatusResponseDto;
+import bsise.server.report.retrieve.dto.ReportStatusRequestDto;
+import bsise.server.report.retrieve.dto.WeeklyReportStatusResponseDto;
+import bsise.server.report.retrieve.service.ReportStatusRetrieveService;
+import jakarta.validation.Valid;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ReportStatusRetrieveController {
+
+    private final ReportStatusRetrieveService reportStatusRetrieveService;
+
+    @GetMapping(value = "/api/v1/daily/status")
+    @ResponseStatus(HttpStatus.OK)
+    public List<DailyReportStatusResponseDto> retrieveDailyReportStatus(
+            @Valid @RequestBody ReportStatusRequestDto requestDto
+    ) {
+        LocalDate now = LocalDate.now();
+        return reportStatusRetrieveService.findDailyReportStatus(UUID.fromString(requestDto.getUserId()), now, now);
+    }
+
+    @GetMapping(value = "/api/v1/weekly/status")
+    @ResponseStatus(HttpStatus.OK)
+    public List<WeeklyReportStatusResponseDto> retrieveWeeklyReportStatus(
+            @Valid @RequestBody ReportStatusRequestDto requestDto
+    ) {
+        LocalDate now = LocalDate.now();
+        return reportStatusRetrieveService.findWeeklyReportStatus(UUID.fromString(requestDto.getUserId()), now, now);
+    }
+}

--- a/src/main/java/bsise/server/report/retrieve/ReportStatusRetrieveController.java
+++ b/src/main/java/bsise/server/report/retrieve/ReportStatusRetrieveController.java
@@ -21,7 +21,7 @@ public class ReportStatusRetrieveController {
 
     private final ReportStatusRetrieveService reportStatusRetrieveService;
 
-    @GetMapping(value = "/api/v1/daily/status")
+    @GetMapping(value = "/api/v1/reports/daily/status")
     @ResponseStatus(HttpStatus.OK)
     public List<DailyReportStatusResponseDto> retrieveDailyReportStatus(
             @Valid @RequestBody ReportStatusRequestDto requestDto
@@ -30,7 +30,7 @@ public class ReportStatusRetrieveController {
         return reportStatusRetrieveService.findDailyReportStatus(UUID.fromString(requestDto.getUserId()), now, now);
     }
 
-    @GetMapping(value = "/api/v1/weekly/status")
+    @GetMapping(value = "/api/v1/reports/weekly/status")
     @ResponseStatus(HttpStatus.OK)
     public List<WeeklyReportStatusResponseDto> retrieveWeeklyReportStatus(
             @Valid @RequestBody ReportStatusRequestDto requestDto

--- a/src/main/java/bsise/server/report/retrieve/dto/DailyReportDto.java
+++ b/src/main/java/bsise/server/report/retrieve/dto/DailyReportDto.java
@@ -1,0 +1,9 @@
+package bsise.server.report.retrieve.dto;
+
+import java.time.LocalDateTime;
+
+public interface DailyReportDto {
+
+    String getDailyReportId();
+    LocalDateTime getCreatedAt();
+}

--- a/src/main/java/bsise/server/report/retrieve/dto/DailyReportStatusResponseDto.java
+++ b/src/main/java/bsise/server/report/retrieve/dto/DailyReportStatusResponseDto.java
@@ -1,0 +1,32 @@
+package bsise.server.report.retrieve.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class DailyReportStatusResponseDto {
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+    private final LocalDate date;
+
+    private final int totalCount;
+
+    private final boolean available;
+
+    private final boolean analyzed;
+
+    public static DailyReportStatusResponseDto create(LocalDate date, List<DailyReportDto> letters) {
+        boolean analyzed = letters.stream()
+                .allMatch(letter -> letter.getDailyReportId() != null);
+
+        return new DailyReportStatusResponseDto(date, letters.size(), !analyzed, analyzed);
+    }
+
+    public static DailyReportStatusResponseDto createFalseStatus(LocalDate date) {
+        return new DailyReportStatusResponseDto(date, 0, false, false);
+    }
+}

--- a/src/main/java/bsise/server/report/retrieve/dto/ReportStatusRequestDto.java
+++ b/src/main/java/bsise/server/report/retrieve/dto/ReportStatusRequestDto.java
@@ -1,0 +1,13 @@
+package bsise.server.report.retrieve.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ReportStatusRequestDto {
+
+    @NotBlank
+    private String userId;
+}

--- a/src/main/java/bsise/server/report/retrieve/dto/WeeklyReportDto.java
+++ b/src/main/java/bsise/server/report/retrieve/dto/WeeklyReportDto.java
@@ -1,0 +1,9 @@
+package bsise.server.report.retrieve.dto;
+
+import java.time.LocalDateTime;
+
+public interface WeeklyReportDto {
+
+    String getWeeklyReportId();
+    LocalDateTime getLetterCreatedAt();
+}

--- a/src/main/java/bsise/server/report/retrieve/dto/WeeklyReportStatusResponseDto.java
+++ b/src/main/java/bsise/server/report/retrieve/dto/WeeklyReportStatusResponseDto.java
@@ -1,0 +1,53 @@
+package bsise.server.report.retrieve.dto;
+
+import static bsise.server.report.retrieve.service.CustomDateUtils.*;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
+import java.util.List;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class WeeklyReportStatusResponseDto {
+
+    private final int weekOfYear;
+
+    private final String weekName;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+    private final LocalDate startDate;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+    private final LocalDate endDate;
+
+    private final int totalCount; // 해당 주차에 속하는 편지 개수
+
+    private final boolean available;
+
+    private final boolean analyzed;
+
+    public static WeeklyReportStatusResponseDto create(int weekOfYear, List<LocalDate> dates, List<WeeklyReportDto> reports) {
+        boolean analyzed = reports.stream()
+                .allMatch(report -> report.getWeeklyReportId() != null);
+
+        LocalDate startDate = dates.get(0).with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+        LocalDate endDate = dates.get(0).with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY));
+
+        return new WeeklyReportStatusResponseDto(
+                weekOfYear, getWeekOfMonth(startDate), startDate, endDate, reports.size(), !analyzed, analyzed
+        );
+    }
+
+    public static WeeklyReportStatusResponseDto createFalseStatus(int weekOfYear, List<LocalDate> dates) {
+        LocalDate startDate = dates.get(0).with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+        LocalDate endDate = dates.get(0).with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY));
+
+        return new WeeklyReportStatusResponseDto(
+                weekOfYear, getWeekOfMonth(startDate), startDate, endDate, 0, false, false
+        );
+    }
+}

--- a/src/main/java/bsise/server/report/retrieve/service/CustomDateUtils.java
+++ b/src/main/java/bsise/server/report/retrieve/service/CustomDateUtils.java
@@ -1,0 +1,62 @@
+package bsise.server.report.retrieve.service;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
+import java.time.temporal.WeekFields;
+
+public class CustomDateUtils {
+
+    private static final WeekFields KOREA = WeekFields.of(DayOfWeek.MONDAY, 4);
+    private static final String WEEK_OF_MONTH_FORMAT = "%d년 %d월 %d주차";
+
+    /**
+     * 주어진 날짜를 `%d년 %d월 %d주차`로 변환하는 함수
+     *
+     * @param localDate 주어진 날짜
+     * @return `%d년 %d월 %d주차`로 변환된 문자열
+     */
+    public static String getWeekOfMonth(LocalDate localDate) {
+        int weekOfMonth = localDate.get(KOREA.weekOfMonth());
+
+        // 2개 달에 껴있는 주일 때 => 이전 달의 마지막 주차로 계산
+        if (weekOfMonth == 0) {
+            LocalDate lastDayOfLastMonth = localDate.with(TemporalAdjusters.firstDayOfMonth()).minusDays(1);
+            return getWeekOfMonth(lastDayOfLastMonth);
+        }
+
+        // 주어진 날짜가 속한 달의 마지막 날
+        LocalDate lastDayOfMonth = localDate.with(TemporalAdjusters.lastDayOfMonth());
+
+        // 주어진 날짜가 마지막 주차이면서, 해당 달의 마지막 요일이 목요일 이전이라면 => 다음달 1주차로 계산
+        if (isLastWeekOfMonth(localDate) && isBeforeThursDay(lastDayOfMonth)) {
+            LocalDate firstDayOfNextMonth = lastDayOfMonth.plusDays(1); // 다음 달 1주차로 넘기기
+            return getWeekOfMonth(firstDayOfNextMonth);
+        }
+
+        return String.format(WEEK_OF_MONTH_FORMAT, localDate.getYear(), localDate.getMonthValue(), weekOfMonth);
+    }
+
+    /**
+     * 주어진 날짜의 요일이 목요일 이전(exclusive)인지 여부를 판단하는 함수
+     *
+     * @param localDate 주어진 날짜
+     * @return 목요일 이전(exclusive)이면 true, 목요일 포함 이후이면 false
+     */
+    private static boolean isBeforeThursDay(LocalDate localDate) {
+        return localDate.getDayOfWeek().compareTo(DayOfWeek.THURSDAY) < 0;
+    }
+
+    /**
+     * 주어진 날짜가 해당 월의 마지막 주차에 해당하는지 여부를 판단하는 함수
+     *
+     * @param localDate 주어진 날짜
+     * @return 예를 들어, 12월 마지막 주차가 12월 4주차이며, 주어진 날짜가 해당 월의 마지막 주차라면 true, 마지막 주차가 아니라면 false
+     */
+    private static boolean isLastWeekOfMonth(LocalDate localDate) {
+        int weekOfMonth = localDate.get(KOREA.weekOfMonth());
+        LocalDate lastDayOfMonth = localDate.with(TemporalAdjusters.lastDayOfMonth());
+
+        return weekOfMonth == lastDayOfMonth.get(KOREA.weekOfMonth());
+    }
+}

--- a/src/main/java/bsise/server/report/retrieve/service/ReportStatusRetrieveService.java
+++ b/src/main/java/bsise/server/report/retrieve/service/ReportStatusRetrieveService.java
@@ -1,0 +1,133 @@
+package bsise.server.report.retrieve.service;
+
+import static java.util.stream.Collectors.groupingBy;
+
+import bsise.server.letter.LetterRepository;
+import bsise.server.report.retrieve.dto.DailyReportDto;
+import bsise.server.report.retrieve.dto.DailyReportStatusResponseDto;
+import bsise.server.report.retrieve.dto.WeeklyReportDto;
+import bsise.server.report.retrieve.dto.WeeklyReportStatusResponseDto;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.temporal.WeekFields;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ReportStatusRetrieveService {
+
+    private static final WeekFields WEEK_FIELDS = WeekFields.of(DayOfWeek.MONDAY, 4);
+    private static final int DEFAULT_PREVIOUS_RANGE = 1;
+
+    private final LetterRepository letterRepository;
+
+    /**
+     * 유저의 ID(uuid)를 통해 일자 별 일일 분석 리포트 상태 조회
+     *
+     * @param userId 유저의 아이디
+     * @param targetDate 대상 날짜
+     * @param endDate 검색 범위 마지막 날짜
+     * @return 일자 별 일일 분석 리포트 상태 리스트
+     */
+    public List<DailyReportStatusResponseDto> findDailyReportStatus(UUID userId, LocalDate targetDate, LocalDate endDate) {
+        // 타겟 날짜로부터 한 달 전 날짜
+        LocalDate oneMonthAgo = targetDate.minusMonths(DEFAULT_PREVIOUS_RANGE);
+
+        // 편지 리스트 조회
+        List<DailyReportDto> letters = letterRepository.findDailyReportIdByDateRange(userId, convertToMin(oneMonthAgo), convertToMax(endDate));
+
+        // LocalDate 로 변환 후 날짜 기준으로 그루핑
+        Map<LocalDate, List<DailyReportDto>> lettersByDate = letters.stream()
+                .collect(groupingBy(letter -> letter.getCreatedAt().toLocalDate()));
+
+        // 한 달 이전부터 타겟 날짜를 포함한 모든 일자 구하기
+        List<LocalDate> totalDateRange = getInclusiveDateRange(oneMonthAgo, targetDate);
+
+        // 해당 날짜에 작성한 편지가 있으면 분석 상태 표시 없으면 항상 분석 불가능한 상태로 응답
+        return totalDateRange.stream()
+                .map(date -> lettersByDate.containsKey(date)
+                        ? DailyReportStatusResponseDto.create(date, lettersByDate.get(date))
+                        : DailyReportStatusResponseDto.createFalseStatus(date))
+                .toList();
+    }
+
+    /**
+     * 유저의 ID(uuid)를 통해 주간 별 주간 분석 리포트 상태 조회
+     *
+     * @param userId 유저의 아이디
+     * @param targetDate 대상 날짜
+     * @param endDate 검색 범위 마지막 날짜
+     * @return 주간 별 주간 분석 리포트 상태 리스트
+     */
+    public List<WeeklyReportStatusResponseDto> findWeeklyReportStatus(UUID userId, LocalDate targetDate, LocalDate endDate) {
+        // 타겟 날짜로부터 한 달 전 날짜
+        LocalDate oneMonthAgo = targetDate.minusMonths(DEFAULT_PREVIOUS_RANGE);
+
+        // 편지 리스트 조회
+        List<WeeklyReportDto> dailyReports = letterRepository.findWeeklyReportIdByDateRange(userId, convertToMin(oneMonthAgo), convertToMax(endDate));
+
+        // 편지 작성일을 weekOfYear 로 변환 후 주간 기준으로 그루핑
+        Map<Integer, List<WeeklyReportDto>> reportsByWeekOfYear = dailyReports.stream()
+                .collect(groupingBy(report -> report.getLetterCreatedAt().get(WEEK_FIELDS.weekOfWeekBasedYear())));
+
+        // 한 달 이전부터 타겟 날짜를 포함한 주간별 일자 구하기
+        Map<Integer, List<LocalDate>> totalWeekRange = getInclusiveWeekRange(oneMonthAgo, targetDate);
+
+        return totalWeekRange.entrySet().stream()
+                .map(entry -> {
+                    Integer weekOfYear = entry.getKey();
+                    List<LocalDate> datesByWeek = entry.getValue();
+                    return reportsByWeekOfYear.containsKey(weekOfYear)
+                            ? WeeklyReportStatusResponseDto.create(weekOfYear, datesByWeek, reportsByWeekOfYear.get(weekOfYear))
+                            : WeeklyReportStatusResponseDto.createFalseStatus(weekOfYear, datesByWeek);
+                })
+                .toList();
+    }
+
+    private LocalDateTime convertToMin(LocalDate localDate) {
+        return LocalDateTime.of(localDate, LocalTime.MIN);
+    }
+
+    private LocalDateTime convertToMax(LocalDate localDate) {
+        return LocalDateTime.of(localDate, LocalTime.MAX);
+    }
+
+    /**
+     * 주어진 날짜 범위로부터 1달 전까지의 일자 별 달력 생성 (마지막 일자 포함)
+     *
+     * @param startDate (inclusive) 범위의 시작일
+     * @param endDate   (inclusive) 범위의 종료일
+     * @return 시작일부터 종료일을 모두 포함하는 날짜(LocalDate) (이른 날짜부터 정렬된 상태)
+     */
+    private List<LocalDate> getInclusiveDateRange(LocalDate startDate, LocalDate endDate) {
+        return startDate.datesUntil(endDate.plusDays(1)).toList();
+    }
+
+    /**
+     * 주어진 날짜 범위로부터 1달 전까지의 주간 별 달력 생성 (마지막 일자 포함)
+     *
+     * @param startDate (inclusive) 범위의 시작일
+     * @param endDate   (inclusive) 범위의 종료일
+     * @return 시작일부터 종료일을 모두 포함하는 주간 별로 그룹화된 날짜 (weekOfYear 를 기준으로 이른 날짜부터 정렬된 상태)
+     */
+    private Map<Integer, List<LocalDate>> getInclusiveWeekRange(LocalDate startDate, LocalDate endDate) {
+        return startDate.datesUntil(endDate.plusDays(1))
+                .collect(Collectors.groupingBy(
+                        date -> date.get(WEEK_FIELDS.weekOfWeekBasedYear()),
+                        TreeMap::new,
+                        Collectors.toList()
+                ));
+    }
+}

--- a/src/main/java/bsise/server/report/weekly/WeeklyReportRepository.java
+++ b/src/main/java/bsise/server/report/weekly/WeeklyReportRepository.java
@@ -1,0 +1,10 @@
+package bsise.server.report.weekly;
+
+import bsise.server.report.WeeklyReport;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface WeeklyReportRepository extends JpaRepository<WeeklyReport, UUID> {
+}

--- a/src/test/java/bsise/server/BsideApplicationTests.java
+++ b/src/test/java/bsise/server/BsideApplicationTests.java
@@ -2,8 +2,12 @@ package bsise.server;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 @SpringBootTest
+@Testcontainers
+@ActiveProfiles("test")
 class BsideApplicationTests {
 
     @Test

--- a/src/test/java/bsise/server/report/retrieve/service/ReportStatusRetrieveServiceTest.java
+++ b/src/test/java/bsise/server/report/retrieve/service/ReportStatusRetrieveServiceTest.java
@@ -1,0 +1,433 @@
+package bsise.server.report.retrieve.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import bsise.server.auth.OAuth2Provider;
+import bsise.server.letter.Letter;
+import bsise.server.letter.LetterRepository;
+import bsise.server.report.CoreEmotion;
+import bsise.server.report.DailyReport;
+import bsise.server.report.WeeklyReport;
+import bsise.server.report.daily.DailyReportRepository;
+import bsise.server.report.retrieve.dto.DailyReportStatusResponseDto;
+import bsise.server.report.retrieve.dto.WeeklyReportStatusResponseDto;
+import bsise.server.report.weekly.WeeklyReportRepository;
+import bsise.server.user.domain.Preference;
+import bsise.server.user.domain.Role;
+import bsise.server.user.domain.User;
+import bsise.server.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import java.lang.reflect.Field;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.temporal.TemporalAdjusters;
+import java.time.temporal.WeekFields;
+import java.util.List;
+import java.util.stream.Stream;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+@SpringBootTest
+@ActiveProfiles("test")
+class ReportStatusRetrieveServiceTest {
+
+    @Autowired
+    private ReportStatusRetrieveService reportStatusRetrieveService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private DailyReportRepository dailyReportRepository;
+
+    @Autowired
+    private WeeklyReportRepository weeklyReportRepository;
+
+    @Autowired
+    private LetterRepository letterRepository;
+
+    @Transactional
+    @Test
+    void findDailyAnalysisStatus() throws NoSuchFieldException, IllegalAccessException {
+        // given
+        User user = createTestUser();
+
+        // 2024-11-15 1건(일일 분석 0건), 2024-11-30 2건(일일 분석 1건), 2024-12-29 2건(일일 분석 0건), 2024-12-30 1건(일일 분석 0건)
+        createLetterScenarios1(user);
+
+        // when & then
+        verifyFirstCase(user);
+        verifySecondCase(user);
+        verifyThirdCase(user);
+    }
+
+    // 2024-11-15 1건(분석 수행 0건), 2024-11-30 2건(분석 수행 1건), 2024-12-29 2건(분석 수행 0건), 2024-12-30 1건(분석 수행 0건)
+    private void createLetterScenarios1(User user)
+            throws NoSuchFieldException, IllegalAccessException {
+        // 2024-11-15: 1건
+        createLetterByLocalDate(user, LocalDate.of(2024, 11, 15));
+
+        /* 2024-11-30: 전체 2건 */
+        createLetterByLocalDate(user, LocalDate.of(2024, 11, 30));
+
+        // 2024-11-30: 일일 분석된 편지 1건
+        Letter analyzedLetter = createLetterByLocalDate(user, LocalDate.of(2024, 11, 30));
+        DailyReport dailyReport = createTestDailyReport(LocalDate.of(2024, 11, 30));
+        analyzedLetter.setDailyReport(dailyReport);
+
+        // 2024-12-29: 2건
+        createLetterByLocalDate(user, LocalDate.of(2024, 12, 29));
+        createLetterByLocalDate(user, LocalDate.of(2024, 12, 29));
+
+        // 2024-12-30: 1건
+        createLetterByLocalDate(user, LocalDate.of(2024, 12, 30));
+    }
+
+
+
+    private void verifyFirstCase(User user) {
+        LocalDate targetDate = LocalDate.of(2024, 11, 30);
+        List<DailyReportStatusResponseDto> dailyReportStatus = reportStatusRetrieveService.findDailyReportStatus(user.getId(), targetDate, targetDate);
+
+        List<LocalDate> totalDates = targetDate.minusMonths(1).datesUntil(targetDate.plusDays(1)).toList();
+
+        assertAll(
+                "이미 분석을 실행한 2024-11-30 조회 시 2024-11-15 1건만 분석 가능하다.",
+                () -> assertThat(dailyReportStatus).hasSize(32),
+                () -> assertThat(dailyReportStatus).extracting(DailyReportStatusResponseDto::getDate).isEqualTo(totalDates),
+                () -> assertThat(dailyReportStatus)
+                        .filteredOn(dto -> dto.getDate().isEqual(LocalDate.of(2024, 11, 15)))
+                        .extracting(DailyReportStatusResponseDto::isAvailable)
+                        .containsExactly(true),
+                () -> assertThat(dailyReportStatus)
+                        .filteredOn(dto -> dto.getDate().isEqual(LocalDate.of(2024, 11, 15)))
+                        .extracting(DailyReportStatusResponseDto::isAnalyzed)
+                        .containsExactly(false)
+        );
+    }
+
+    private void verifySecondCase(User user) {
+        LocalDate targetDate = LocalDate.of(2024, 12, 29);
+        List<DailyReportStatusResponseDto> dailyReportStatus = reportStatusRetrieveService.findDailyReportStatus(user.getId(), targetDate, targetDate);
+
+        List<LocalDate> totalDates = targetDate.minusMonths(1).datesUntil(targetDate.plusDays(1)).toList();
+
+        assertAll(
+                "한 번도 분석하지 않은 2024-12-29 조회 시 2024-12-29 에 작성한 글 2건만 분석 가능하다.",
+                () -> assertThat(dailyReportStatus).hasSize(31),
+                () -> assertThat(dailyReportStatus).extracting(DailyReportStatusResponseDto::getDate).isEqualTo(totalDates),
+                () -> assertThat(dailyReportStatus)
+                        .filteredOn(dto -> dto.getDate().isEqual(LocalDate.of(2024, 12, 29)))
+                        .extracting(DailyReportStatusResponseDto::isAvailable)
+                        .containsExactly(true),
+                () -> assertThat(dailyReportStatus)
+                        .filteredOn(dto -> dto.getDate().isEqual(LocalDate.of(2024, 12, 29)))
+                        .extracting(DailyReportStatusResponseDto::isAnalyzed)
+                        .containsExactly(false)
+        );
+    }
+
+    private void verifyThirdCase(User user) {
+        LocalDate targetDate = LocalDate.of(2024, 12, 30);
+        List<DailyReportStatusResponseDto> dailyReportStatus = reportStatusRetrieveService.findDailyReportStatus(user.getId(), targetDate, targetDate);
+
+        List<LocalDate> totalDates = targetDate.minusMonths(1).datesUntil(targetDate.plusDays(1)).toList();
+
+        assertAll(
+                "한 번도 분석하지 않은 2024-12-30 조회 시 2024-12-29 작성 글 2건, 2024-12-30 작성 글 1건에 대해 분석 가능하다.",
+                () -> assertThat(dailyReportStatus).hasSize(31),
+                () -> assertThat(dailyReportStatus).extracting(DailyReportStatusResponseDto::getDate).isEqualTo(totalDates),
+                () -> assertThat(dailyReportStatus)
+                        .filteredOn(dto -> dto.getDate().isEqual(LocalDate.of(2024, 12, 29)))
+                        .extracting(DailyReportStatusResponseDto::isAvailable)
+                        .containsExactly(true),
+                () -> assertThat(dailyReportStatus)
+                        .filteredOn(dto -> dto.getDate().isEqual(LocalDate.of(2024, 12, 30)))
+                        .extracting(DailyReportStatusResponseDto::isAvailable)
+                        .containsExactly(true),
+                () -> assertThat(dailyReportStatus)
+                        .filteredOn(dto -> dto.getDate().isEqual(LocalDate.of(2024, 12, 29)))
+                        .extracting(DailyReportStatusResponseDto::isAnalyzed)
+                        .containsExactly(false),
+                () -> assertThat(dailyReportStatus)
+                        .filteredOn(dto -> dto.getDate().isEqual(LocalDate.of(2024, 12, 30)))
+                        .extracting(DailyReportStatusResponseDto::isAnalyzed)
+                        .containsExactly(false)
+        );
+    }
+
+    @Transactional
+    @Test
+    void findWeeklyReportStatus() throws NoSuchFieldException, IllegalAccessException {
+        // given
+        User user = createTestUser();
+
+        // 2024-11-30 (일일 분석 1, 주간 분석 1), 2024-12-29 (일일 분석 0, 주간 분석 0), 2024-12-30 (일일 분석 1, 주간 분석 0)
+        createLetterScenarios2(user);
+
+        // when
+        /* 이미 주간 분석을 실행한 2024-11-30 날짜에 조회 시 */
+        LocalDate targetDate = LocalDate.of(2024, 11, 30);
+        List<WeeklyReportStatusResponseDto> weeklyReportStatus = reportStatusRetrieveService.findWeeklyReportStatus(user.getId(), targetDate, targetDate);
+
+        /* 일일 분석과 주간 분석을 하지않은 2024-12-29 날짜일 때 조회 시  */
+        LocalDate targetDate2 = LocalDate.of(2024, 12, 29);
+        List<WeeklyReportStatusResponseDto> weeklyReportStatus2 = reportStatusRetrieveService.findWeeklyReportStatus(user.getId(), targetDate2, targetDate2);
+
+        /* 주간 분석을 하지않은 2024-12-30 날짜일 때 조회 시  */
+        LocalDate targetDate3 = LocalDate.of(2024, 12, 30);
+        List<WeeklyReportStatusResponseDto> weeklyReportStatus3 = reportStatusRetrieveService.findWeeklyReportStatus(user.getId(), targetDate3, targetDate3);
+
+        // then
+        assertAll(
+                "2024-11-30일에 이미 주간 분석을 실행한 주에 조회 시 주간 분석이 가능한 주 개수는 0건이다.",
+                () -> assertThat(weeklyReportStatus).hasSize(5),
+                () -> assertThat(weeklyReportStatus).filteredOn(WeeklyReportStatusResponseDto::isAvailable)
+                        .extracting(WeeklyReportStatusResponseDto::getWeekName).isEmpty()
+        );
+
+        assertAll(
+                "2024-12-29일에 조회 시 주간 분석이 가능한 주 개수는 1건이다.",
+                () -> assertThat(weeklyReportStatus2).hasSize(5),
+                () -> assertThat(weeklyReportStatus2).filteredOn(WeeklyReportStatusResponseDto::isAvailable)
+                        .extracting(WeeklyReportStatusResponseDto::getWeekName).containsExactly("2024년 12월 4주차")
+        );
+
+        assertAll(
+                "2024-12-30일에 조회 시 주간 분석이 가능한 주 개수는 2건이다.",
+                () -> assertThat(weeklyReportStatus3).hasSize(6),
+                () -> assertThat(weeklyReportStatus3).filteredOn(WeeklyReportStatusResponseDto::isAvailable)
+                        .extracting(WeeklyReportStatusResponseDto::getWeekName).contains("2024년 12월 4주차", "2025년 1월 1주차")
+        );
+    }
+
+    private void createLetterScenarios2(User user)
+            throws NoSuchFieldException, IllegalAccessException {
+        /* 2024-11-30: 편지 1건 (일일 분석 수행 o, 주간 분석 수행 o) */
+        Letter analyzedLetter = createLetterByLocalDate(user, LocalDate.of(2024, 11, 30));
+        DailyReport dailyReport = createTestDailyReport(LocalDate.of(2024, 11, 30));
+        analyzedLetter.setDailyReport(dailyReport);
+
+        WeeklyReport weeklyReport = WeeklyReport.builder()
+                .cheerUp("test")
+                .weeklyName("test")
+                .publishedCount(0)
+                .unpublishedCount(0)
+                .build();
+        weeklyReportRepository.save(weeklyReport);
+
+        dailyReport.setWeeklyReport(weeklyReport);
+        dailyReportRepository.save(dailyReport);
+
+        /* 2024-12-29: 편지 1건 (일일 분석 수행 x, 주간 분석 수행 x) */
+        createLetterByLocalDate(user, LocalDate.of(2024, 12, 29));
+
+        /* 2024-12-30: 편지 1건 (일일 분석 수행 o, 주간 분석 수행 x) */
+        Letter analyzedLetter3 = createLetterByLocalDate(user, LocalDate.of(2024, 12, 30));
+        DailyReport dailyReport3 = createTestDailyReport(LocalDate.of(2024, 12, 29));
+        analyzedLetter3.setDailyReport(dailyReport3);
+    }
+
+    private DailyReport createTestDailyReport(LocalDate targetDate) {
+        DailyReport dailyReport = DailyReport.builder()
+                .coreEmotion(CoreEmotion.기쁨)
+                .description("test")
+                .targetDate(targetDate)
+                .build();
+
+        return dailyReportRepository.save(dailyReport);
+    }
+
+    private User createTestUser() {
+        User user = User.builder()
+                .username("tester1")
+                .nickname("tester1")
+                .email("test")
+                .preference(Preference.F)
+                .provider(OAuth2Provider.KAKAO)
+                .role(Role.OAUTH)
+                .build();
+
+        return userRepository.save(user);
+    }
+
+    private @NotNull Letter createLetterByLocalDate(User user, LocalDate localDate)
+            throws NoSuchFieldException, IllegalAccessException {
+        Letter letter = Letter.builder()
+                .user(user)
+                .build();
+
+        letterRepository.save(letter);
+
+        // superClass => getDeclaredField() 사용
+        Field createdAt = Letter.class.getSuperclass().getDeclaredField("createdAt");
+        createdAt.setAccessible(true);
+        createdAt.set(letter, LocalDateTime.of(localDate, LocalTime.MIN));
+
+        letterRepository.saveAndFlush(letter);
+
+        return letter;
+    }
+
+    @DisplayName("날짜가 주어지면 해당 날짜가 속한 주의 시작 일자와 마지막 일자를 계산할 수 있다")
+    @ParameterizedTest
+    @MethodSource("provideTargetDate")
+    void inclusiveRange(LocalDate targetDate, LocalDate expectedStartDate) {
+        // given
+        LocalDate startDate = targetDate.minusMonths(1);
+
+        // when
+        List<LocalDate> dates = startDate.datesUntil(targetDate.plusDays(1)).toList();
+
+        // then
+        LocalDate actualStartDate = dates.get(0);
+        LocalDate lastDate = dates.get(dates.size() - 1);
+
+        assertThat(actualStartDate).isEqualTo(expectedStartDate);
+        assertThat(lastDate).isEqualTo(targetDate);
+    }
+
+    private static Stream<Arguments> provideTargetDate() {
+        return Stream.of(
+                Arguments.of(
+                        LocalDate.of(2024, 11, 15),
+                        LocalDate.of(2024, 10, 15)
+                ),
+                Arguments.of(
+                        LocalDate.of(2024, 11, 30),
+                        LocalDate.of(2024, 10, 30)
+                ),
+                Arguments.of(
+                        LocalDate.of(2024, 12, 1),
+                        LocalDate.of(2024, 11, 1)
+                ),
+                Arguments.of(
+                        LocalDate.of(2024, 12, 15),
+                        LocalDate.of(2024, 11, 15)
+                ),
+                Arguments.of(
+                        LocalDate.of(2024, 12, 31),
+                        LocalDate.of(2024, 11, 30)
+                ),
+                Arguments.of(
+                        LocalDate.of(2025, 1, 1),
+                        LocalDate.of(2024, 12, 1)
+                )
+        );
+    }
+
+    @DisplayName("특정 날짜가 주어지면 한국(ISO) 기준으로 weekOfYear 를 계산할 수 있다")
+    @ParameterizedTest
+    @MethodSource("provideTargetDateAndWeekOfYear")
+    void weekOfWeekByKoreaWeekFields(LocalDate targetDate, int expectedWeekOfYear) {
+        // given
+        WeekFields weekFields = WeekFields.of(DayOfWeek.MONDAY, 4);
+
+        // when
+        int weekOfYear = targetDate.get(weekFields.weekOfWeekBasedYear());
+
+        // then
+        assertThat(weekOfYear).isEqualTo(expectedWeekOfYear);
+    }
+
+    public static Stream<Arguments> provideTargetDateAndWeekOfYear() {
+        return Stream.of(
+                Arguments.of(LocalDate.of(2024, 12, 29), 52),
+                Arguments.of(LocalDate.of(2024, 12, 31), 1),
+                Arguments.of(LocalDate.of(2025, 1, 1), 1),
+                Arguments.of(LocalDate.of(2025, 12, 28), 52),
+                Arguments.of(LocalDate.of(2025, 12, 31), 1),
+                Arguments.of(LocalDate.of(2026, 1, 1), 1),
+                Arguments.of(LocalDate.of(2026, 1, 5), 2),
+                Arguments.of(LocalDate.of(2026, 12, 27), 52),
+                Arguments.of(LocalDate.of(2026, 12, 31), 53),
+                Arguments.of(LocalDate.of(2027, 1, 1), 53),
+                Arguments.of(LocalDate.of(2027, 1, 4), 1)
+        );
+    }
+
+    @DisplayName("targetDate 에 따른 해당 주의 시작 일자와 마지막 일자를 계산할 수 있다")
+    @ParameterizedTest
+    @MethodSource("provideTargetDateAndExpectedDates")
+    void findFirstDayOfWeekAndLastDayOfWeek(LocalDate targetDate, LocalDate expectedStartDate,
+                                            LocalDate expectedEndDate) {
+        // when
+        LocalDate startDateByISO = targetDate.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+        LocalDate endDateByISO = targetDate.with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY));
+
+        // ISO => 동일한 결과
+        LocalDate startDateByKorea = targetDate.with(WeekFields.ISO.getFirstDayOfWeek());
+        LocalDate endDateByKorea = startDateByKorea.plusDays(6);
+
+        // then
+        assertThat(startDateByISO).isEqualTo(expectedStartDate);
+        assertThat(endDateByISO).isEqualTo(expectedEndDate);
+        assertThat(startDateByKorea).isEqualTo(expectedStartDate);
+        assertThat(endDateByKorea).isEqualTo(expectedEndDate);
+    }
+
+    private static Stream<Arguments> provideTargetDateAndExpectedDates() {
+        return Stream.of(
+                Arguments.of(
+                        LocalDate.of(2024, 11, 28),
+                        LocalDate.of(2024, 11, 25),
+                        LocalDate.of(2024, 12, 1)
+                ),
+                Arguments.of(
+                        LocalDate.of(2024, 12, 29),
+                        LocalDate.of(2024, 12, 23),
+                        LocalDate.of(2024, 12, 29)
+                ),
+                Arguments.of(
+                        LocalDate.of(2025, 1, 1),
+                        LocalDate.of(2024, 12, 30),
+                        LocalDate.of(2025, 1, 5)
+                )
+        );
+    }
+
+    @DisplayName("주어진 날짜로부터 한국 기준(ISO) weekOfYear 와 weekOfMonth 를 `yyyy년 m월 n주차`로 계산할 수 있다")
+    @ParameterizedTest
+    @MethodSource("provideTargetDateAndExpectedWeekOfYear")
+    void test(LocalDate targetDate, int expectedWeekOfYear, String expectedDayOfMonth) {
+        // given
+        WeekFields korea = WeekFields.of(DayOfWeek.MONDAY, 4);
+
+        // when
+        int weekOfYearByISO = targetDate.get(WeekFields.ISO.weekOfWeekBasedYear());
+        int weekOfYearByKorea = targetDate.get(korea.weekOfWeekBasedYear());
+
+        String weekOfMonth = CustomDateUtils.getWeekOfMonth(targetDate);
+
+        // then
+        assertThat(weekOfYearByISO).isEqualTo(expectedWeekOfYear);
+        assertThat(weekOfYearByKorea).isEqualTo(expectedWeekOfYear);
+        assertThat(weekOfMonth).isEqualTo(expectedDayOfMonth);
+    }
+
+    private static Stream<Arguments> provideTargetDateAndExpectedWeekOfYear() {
+        return Stream.of(
+                Arguments.of(LocalDate.of(2024, 11, 28), 48, "2024년 11월 4주차"),
+                Arguments.of(LocalDate.of(2024, 12, 1), 48, "2024년 11월 4주차"),
+                Arguments.of(LocalDate.of(2024, 12, 3), 49, "2024년 12월 1주차"),
+                Arguments.of(LocalDate.of(2024, 12, 23), 52, "2024년 12월 4주차"),
+                Arguments.of(LocalDate.of(2024, 12, 29), 52, "2024년 12월 4주차"),
+                Arguments.of(LocalDate.of(2024, 12, 31), 1, "2025년 1월 1주차"),
+                Arguments.of(LocalDate.of(2025, 1, 1), 1, "2025년 1월 1주차"),
+                Arguments.of(LocalDate.of(2025, 12, 31), 1, "2026년 1월 1주차"),
+                Arguments.of(LocalDate.of(2026, 1, 1), 1, "2026년 1월 1주차")
+        );
+    }
+}

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -1,0 +1,50 @@
+spring:
+  config:
+    activate:
+      on-profile: test
+  datasource:
+    url: jdbc:tc:mysql:8.0.39:///test_db #?TC_INITSCRIPT=file:src/test/resources/scheme.sql
+    username: test
+    password: test1234
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        format_sql: true
+        highlight_sql: true
+  docker:
+    compose:
+      skip:
+        in-tests: false
+  data:
+    redis:
+      host: localhost
+      port: 6379
+logging:
+  level:
+    bsise.server: debug
+    org:
+      hibernate:
+        SQL: debug
+        orm:
+          jdbc:
+            bind: trace
+
+clova:
+  api:
+    key: none
+  apigw:
+    key: none
+  request:
+    id: none
+security:
+  jwt:
+    token:
+      access-key: SpringSecurityKey_!@Upup-radio_https://upup-radio.site
+      refresh-key: SpringSecurityKey_!R2fre2h@Upup-radio_https://upup-radio.site
+  base-url: https://upup-radio.site
+  kakao-admin-key: none
+redis:
+  expire: 7200
+  limit: 10


### PR DESCRIPTION
- 요청일 포함 1달 전까지 모든 날짜에 대한 (데일리, 위클리) 리포트 상태 조회
- ISO 국제 표준 주차 변환법 사용(한국이 이에 해당)
- native query 작성으로 드라이빙 테이블이 letter 테이블이 되도록 유도
- 데일리 리포트 상태 조회
    - 인터페이스 기반 closed 프로젝션 적용 (DailyReportDto)
- 위클리 리포트 상태 조회
    - 인터페이스 기반 closed 프로젝션 적용 (WeeklyReportDto)
    - 주차별 한글 이름으로 변환 기능
    - 데일리 리포트가 존재하지 않아도 편지가 존재하면 위클리 리포트 생성 가능으로 간주