### PR TITLE
WithinMonths 검증 어노테이션 직접 개월 수 설정할 수 있도록 리팩토링

### DIFF
--- a/src/main/java/bsise/server/report/daily/dto/DailyReportDto.java
+++ b/src/main/java/bsise/server/report/daily/dto/DailyReportDto.java
@@ -1,6 +1,6 @@
 package bsise.server.report.daily.dto;
 
-import bsise.server.validation.constraints.WithinLastMonth;
+import bsise.server.report.daily.validation.WithinMonths;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
@@ -21,7 +21,7 @@ public class DailyReportDto {
         private String userId;
 
         @NotNull(message = "생성 요청 날짜는 필수 요청 값입니다.")
-        @WithinLastMonth(message = "생성 요청 날짜는 오늘 포함 한달 이전까지만 가능합니다.")
+        @WithinMonths(message = "생성 요청 날짜는 오늘 포함 한달 이전까지만 가능합니다.")
         private LocalDate date;
     }
 }

--- a/src/main/java/bsise/server/report/daily/validation/WithinLastMonthValidator.java
+++ b/src/main/java/bsise/server/report/daily/validation/WithinLastMonthValidator.java
@@ -1,12 +1,18 @@
-package bsise.server.validation;
+package bsise.server.report.daily.validation;
 
-import bsise.server.validation.constraints.WithinLastMonth;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 
 import java.time.LocalDate;
 
-public class WithinLastMonthValidator implements ConstraintValidator<WithinLastMonth, LocalDate> {
+public class WithinLastMonthValidator implements ConstraintValidator<WithinMonths, LocalDate> {
+
+    private int months;
+
+    @Override
+    public void initialize(WithinMonths constraintAnnotation) {
+        this.months = constraintAnnotation.months();
+    }
 
     @Override
     public boolean isValid(LocalDate value, ConstraintValidatorContext context) {
@@ -15,9 +21,9 @@ public class WithinLastMonthValidator implements ConstraintValidator<WithinLastM
         }
 
         LocalDate now = LocalDate.now();
-        LocalDate oneMonthAgo = now.minusMonths(1);
+        LocalDate oneMonthAgo = now.minusMonths(months);
 
-        // 오늘 또는 한 달 이전 날짜까지만 허용
+        // 오늘 또는 지정된 months 달 이전 날짜까지만 허용
         return !value.isAfter(now) && !value.isBefore(oneMonthAgo);
     }
 }

--- a/src/main/java/bsise/server/report/daily/validation/WithinMonths.java
+++ b/src/main/java/bsise/server/report/daily/validation/WithinMonths.java
@@ -1,6 +1,5 @@
-package bsise.server.validation.constraints;
+package bsise.server.report.daily.validation;
 
-import bsise.server.validation.WithinLastMonthValidator;
 import jakarta.validation.Constraint;
 import jakarta.validation.Payload;
 
@@ -12,7 +11,9 @@ import java.lang.annotation.Target;
 @Constraint(validatedBy = WithinLastMonthValidator.class)
 @Target({ ElementType.FIELD })
 @Retention(RetentionPolicy.RUNTIME)
-public @interface WithinLastMonth {
+public @interface WithinMonths {
+
+    int months() default 1;
 
     String message() default "{bsise.server.validation.constraints.WithinLastMonth.message}";
 


### PR DESCRIPTION
- 오늘 포함 한 달 전까지만 확인할 수 있었던 기존의 `@WIthLastMonth` 어노테이션을, N개월 전까지의 날짜인지 확인할 수 있도록 `@WithinMonths` 어노테이션으로 변경
- months 옵션으로 몇 달 전까지 체크할지 지정 가능

close #27 