### PR TITLE
@FeignClient 에 요청/응답 시 INFO 레벨 로그 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,7 @@ dependencies {
     runtimeOnly 'com.h2database:h2'
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'
+    testImplementation "org.springframework.cloud:spring-cloud-contract-wiremock"
 }
 
 dependencyManagement {

--- a/src/main/java/bsise/server/BsideApplication.java
+++ b/src/main/java/bsise/server/BsideApplication.java
@@ -2,11 +2,9 @@ package bsise.server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
-@EnableFeignClients
 @SpringBootApplication
 public class BsideApplication {
 

--- a/src/main/java/bsise/server/clova/client/ClovaFeignClient.java
+++ b/src/main/java/bsise/server/clova/client/ClovaFeignClient.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 
-@FeignClient(name = "clova-service", url = "https://clovastudio.stream.ntruss.com/testapp/v1/chat-completions/HCX-003")
+@FeignClient(name = "clova-service", url = "${feign.clova.url}")
 public interface ClovaFeignClient {
 
     @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)

--- a/src/main/java/bsise/server/clova/service/ClovaService.java
+++ b/src/main/java/bsise/server/clova/service/ClovaService.java
@@ -14,7 +14,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 
-@Profile("prod")
+@Profile({"prod", "dev"})
 @Service
 @RequiredArgsConstructor
 public class ClovaService {
@@ -28,7 +28,7 @@ public class ClovaService {
     @Value("${clova.request.id}")
     private String requestId;
 
-    private final ClovaFeignClient client;
+    protected final ClovaFeignClient client;
 
     public ClovaResponseDto send(String message) {
         return sendRequestToClova(ClovaLetterReplyRequestDto.from(message));

--- a/src/main/java/bsise/server/clova/service/DummyReportClovaService.java
+++ b/src/main/java/bsise/server/clova/service/DummyReportClovaService.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Service;
  * Clova API 를 사용하지 않고, 더미 데이터를 응답하는 더미 서비스입니다.
  * 테스트 목적으로 생성되었으며, 운영 환경에서 사용할 수 없습니다.
  */
-@Profile({"dev", "test"})
+@Profile({"test"})
 @Service
 public class DummyReportClovaService extends ClovaService {
 
@@ -41,9 +41,8 @@ public class DummyReportClovaService extends ClovaService {
         return DummyDailyReportClovaResponseDto.createDummy(lettersCount);
     }
 
-    // TODO: weeklyReport 구현 선행
     @Override
     public ClovaResponseDto sendWeeklyReportRequest(ClovaWeeklyReportRequestDto dto) {
-        return null;
+        return client.sendToClova("", "", "", dto);
     }
 }

--- a/src/main/java/bsise/server/config/FeignGlobalConfig.java
+++ b/src/main/java/bsise/server/config/FeignGlobalConfig.java
@@ -1,0 +1,90 @@
+package bsise.server.config;
+
+import static feign.Logger.Level.BASIC;
+import static feign.Logger.Level.HEADERS;
+
+import feign.Logger;
+import feign.Request;
+import feign.Response;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.StreamUtils;
+
+@EnableFeignClients("bsise.server")
+@Configuration
+public class FeignGlobalConfig {
+
+    @Bean
+    Logger.Level feignLoggerLevel() {
+        return BASIC;
+    }
+
+    @Bean
+    public CustomFeignLogging customFeignLogging() {
+        return new CustomFeignLogging();
+    }
+
+    @Slf4j
+    static class CustomFeignLogging extends Logger {
+
+        @Override
+        protected void logRequest(String configKey, Level logLevel, Request request) {
+            if (logLevel.ordinal() >= HEADERS.ordinal()) {
+                super.logRequest(configKey, logLevel, request);
+                return;
+            }
+            String stringBody = createRequestStringBody(request);
+            log.info("[{}]---> {} {} {} [Headers]: {} [Body]: {}",
+                    Thread.currentThread().getId(),
+                    request.httpMethod(),
+                    request.url(),
+                    request.protocolVersion(),
+                    request.headers(),
+                    stringBody);
+        }
+
+        private String createRequestStringBody(Request request) {
+            return request.body() == null ? "" : new String(request.body(), StandardCharsets.UTF_8);
+        }
+
+        @Override
+        protected Response logAndRebufferResponse(String configKey, Level logLevel, Response response, long elapsedTime)
+                throws IOException {
+            if (logLevel.ordinal() >= HEADERS.ordinal()) {
+                return super.logAndRebufferResponse(configKey, logLevel, response, elapsedTime);
+            }
+            byte[] byteArray = getResponseBodyByteArray(response);
+            log.info("[{}]<--- {} {} ({}ms) [Body]: {}",
+                    Thread.currentThread().getId(),
+                    response.protocolVersion(),
+                    response.status(),
+                    elapsedTime,
+                    new String(byteArray, StandardCharsets.UTF_8));
+
+            return response.toBuilder().body(byteArray).build();
+        }
+
+        private byte[] getResponseBodyByteArray(Response response) throws IOException {
+            if (response.body() == null) {
+                return new byte[]{};
+            }
+            return StreamUtils.copyToByteArray(response.body().asInputStream());
+        }
+
+        /**
+         * customeFeignLogging 을 빈으로 등록하고, log()와 format()이 없으면 feign 로그 레벨이 HEADERS 이상일 떄, DEBUG 레벨의 로그가 나오지 않음
+         */
+        @Override
+        protected void log(String configKey, String format, Object... args) {
+            log.debug(format(configKey, format, args));
+        }
+
+        protected String format(String configKey, String format, Object... args) {
+            return String.format(methodTag(configKey) + format, args);
+        }
+    }
+}

--- a/src/main/java/bsise/server/report/weekly/service/WeeklyReportService.java
+++ b/src/main/java/bsise/server/report/weekly/service/WeeklyReportService.java
@@ -69,7 +69,6 @@ public class WeeklyReportService {
         ClovaResponseDto clovaResponseDto = clovaService.sendWeeklyReportRequest(
                 ClovaWeeklyReportRequestDto.from(descriptions));
         String resultMessage = clovaResponseDto.getResultMessage();
-        log.info("cheer_up 내용 : {}", resultMessage);
 
         WeeklyDataManager manager = new WeeklyDataManager(startDate); // TODO: util class 로 리팩토링 필요
         WeeklyReport weeklyReport = WeeklyReport.builder()

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -31,3 +31,7 @@ logging:
         orm:
           jdbc:
             bind: trace
+
+feign:
+  clova:
+    url: https://clovastudio.stream.ntruss.com/testapp/v1/chat-completions/HCX-003

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -22,3 +22,7 @@ spring:
     compose:
       skip:
         in-tests: false
+
+feign:
+  clova:
+    url: https://clovastudio.stream.ntruss.com/testapp/v1/chat-completions/HCX-003

--- a/src/test/java/bsise/server/clova/client/ClovaFeignClientTest.java
+++ b/src/test/java/bsise/server/clova/client/ClovaFeignClientTest.java
@@ -1,0 +1,45 @@
+package bsise.server.clova.client;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import bsise.server.clova.dto.ClovaResponseDto;
+import bsise.server.clova.service.DummyReportClovaService;
+import bsise.server.clova.weekly.ClovaWeeklyReportRequestDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@TestPropertySource(properties = "feign.clova.url=http://localhost:${wiremock.server.port}")
+@AutoConfigureWireMock(port = 0)
+class ClovaFeignClientTest {
+
+    @Autowired
+    private DummyReportClovaService clovaService;
+
+    @DisplayName("WireMock을 사용하여 클로바 서버를 모킹하고, FeignClient 의 로그를 확인하는데 사용하세요")
+    @Test
+    void logging() {
+        // given, WireMock을 static import
+        stubFor(post("/")
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"status\":{\"code\":\"20000\",\"message\":\"OK\"},\"result\":{\"message\":{\"role\":\"assistant\",\"content\":\"일상 속에서 크고 작은 문제들로 인해 스트레스를 받고 계시는군요. 많은 고민거리들로 인해 머릿속이 복잡하시겠지만 이럴 때일수록 심호흡을 하고 마음을 가라앉혀 보는 건 어떠세요? 모든 문제를 한 번에 해결할 수는 없으니 우선순위를 정해 하나씩 처리해 나가는 것도 좋은 방법이랍니다. 그러다 보면 어느 순간 상황이 조금씩 나아지고 있음을 느낄 수 있을 거예요.사용자님께서는 진로에 대한 고민과 더불어 학업 및 인간관계에서도 어려움을 겪고 계시는군요. 이런 상황에서는 누구나 불안하고 지칠 수 있어요. 그럼에도 포기하지 않고 꾸준히 노력하시는 모습이 정말 대단하다고 생각해요. 힘들 때는 잠시 쉬어가며 자신을 돌보고, 주변 사람들에게 도움을 요청하는 것도 좋은 방법이니 참고해 보시길 바라요.\"},\"inputLength\":1203,\"outputLength\":166,\"stopReason\":\"stop_before\",\"seed\":3923155011,\"aiFilter\":[{\"groupName\":\"curse\",\"name\":\"insult\",\"score\":\"2\",\"result\":\"OK\"},{\"groupName\":\"curse\",\"name\":\"discrimination\",\"score\":\"2\",\"result\":\"OK\"},{\"groupName\":\"unsafeContents\",\"name\":\"sexualHarassment\",\"score\":\"2\",\"result\":\"OK\"}]}}")));
+
+        // when
+        ClovaWeeklyReportRequestDto dto = ClovaWeeklyReportRequestDto.from("테스트용");
+        ClovaResponseDto result = clovaService.sendWeeklyReportRequest(dto);
+
+        // then
+        assertThat(result).isExactlyInstanceOf(ClovaResponseDto.class);
+    }
+}

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -8,6 +8,11 @@ spring:
     password: test1234
     hikari:
       maximum-pool-size: 40
+#   TestContainer가 필요없는 테스트를 위해 추가
+#    driver-class-name: org.h2.Driver
+#    url: jdbc:h2:mem:~/test
+#    username: sa
+#    password:
   jpa:
     hibernate:
       ddl-auto: create-drop


### PR DESCRIPTION
참고
- FeignGlobalConfig 라고 네이밍한 이유는 `@Configuration` 을 사용할 시, `@EnableFeignClients` 에 설정한 모든 하위 패키지의 FeignClient에게 적용됩니다
    - INFO레벨 로그는 모든 Feign에 적용되어도 된다고 생각했어요
    - 특정 FeignClient 에게만 설정들을 적용하고싶으면 `@Configuration` 만 제거하고(`@Bean`은 냅두구), `@FeignClient` 속성에 configuration이있는데, 이곳에  `@Configuration` 제거한 class 를 명시해주면 됩니다.
- INFO레벨 로그에 나오는 값을 수정하고 싶다면 `CustomFeignLogging.class`에서 해당 log.info 부분을 찾아서 수정하면 됩니다. 
```
ex) log.info("[{}]---> {} {} {} [Headers]: {} [Body]: {}",
``` 

실행
- test.yml에서 mysql 설정 -> 인메모리h2 설정으로 변경
- ClovaFeignClientTest 의 테스트 실행
- WireMock에서 지원해주는 로그랑, INFO레벨로 나오는 로그가 있을거에요
    - WireMock 은 클로바 서버를 모킹한 것으로 테스트 시에만 로그가 출력되고, 운영 or 개발시에는 WireMock 로그가 나오지 않아요

/logs/info 에서의 결과 이미지
![image](https://github.com/user-attachments/assets/d67d8a4c-d1ec-421a-9695-3a02ea8b2eb6)
