### PR TITLE
nginx read-timeout 120초로 확대

### DIFF
--- a/nginx/dev.upup-radio.conf
+++ b/nginx/dev.upup-radio.conf
@@ -3,6 +3,8 @@ server {
   server_name dev2.upup-radio.site;
   root /usr/share/nginx/html;
 
+  proxy_read_timeout 120s;
+
   location / {
     index index.html index.htm;
     try_files $uri $uri/ /index.html;


### PR DESCRIPTION
- QA 때 위클리 리포트 생성 시간이 120초 걸릴 때가 있어 수정