### PR TITLE
일일분석 분석할 편지가 하나인 경우 해당 일자 대표감정과 편지의 대표감정 일치하도록 변경

### DIFF
--- a/src/main/java/site/radio/clova/dailyReport/DailyReportExtractor.java
+++ b/src/main/java/site/radio/clova/dailyReport/DailyReportExtractor.java
@@ -10,9 +10,26 @@ public class DailyReportExtractor {
         ObjectMapper objectMapper = new ObjectMapper();
 
         try {
-            return objectMapper.readValue(response.getResultMessage(), ClovaDailyAnalysisResult.class);
+            ClovaDailyAnalysisResult clovaDailyAnalysisResult =
+                    objectMapper.readValue(response.getResultMessage(), ClovaDailyAnalysisResult.class);
+            rearrangeCoreEmotions(clovaDailyAnalysisResult);
+            return clovaDailyAnalysisResult;
         } catch (JsonProcessingException e) {
             throw new IllegalArgumentException("답변 형식이 잘못되었습니다. 답변받은 데이터: " + response.getResultMessage(), e);
+        }
+    }
+
+    private static void rearrangeCoreEmotions(ClovaDailyAnalysisResult analysisResult) {
+        if(analysisResult.getLetterAnalyses().size() > 1) {
+            return;
+        }
+        String dailyCoreEmotion = analysisResult.getDailyCoreEmotion();
+        ClovaDailyAnalysisResult.LetterAnalysis letterAnalysis = analysisResult.getLetterAnalyses().get(0);
+        if(dailyCoreEmotion != null) {
+            if(!letterAnalysis.getCoreEmotions().get(0).equals(dailyCoreEmotion)) {
+                letterAnalysis.getCoreEmotions().remove(dailyCoreEmotion);
+                letterAnalysis.getCoreEmotions().add(0, dailyCoreEmotion);
+            }
         }
     }
 }


### PR DESCRIPTION
- 일일 분석 시 편지에 대해 coreEmotion이 여러 개 분석되지만 클라이언트는 각 편지에 대한 coreEmotions 중 가장 첫 번째 인덱스 값만 사용해 보여주고 있음. 따라서 편지 하나만 분석하는 경우 dailyCoreEmotion과 편지의 coreEmotion이 다르게 출력되는 문제 발생.
- 이를 프롬프트를 수정하지 않고 코드 상으로 개선
- DailyReportExtractor에 rearrangeCoreEmotions 메서드를 추가해 만약 편지가 하나인 경우, coreEmotions의 첫 번째 CoreEmotion 값이 dailyCoreEmotion의 값과 같지 않으면 첫 번째 인덱스로 이동시키도록 변경하였음
