### PR TITLE
외부 API 장애 발생 시 원자적으로 롤백되도록 수정

### DIFF
--- a/src/main/java/site/radio/clova/dto/ClovaResponseDto.java
+++ b/src/main/java/site/radio/clova/dto/ClovaResponseDto.java
@@ -73,10 +73,6 @@ public class ClovaResponseDto {
         return result.message.getContent();
     }
 
-    public boolean hasFallbackMessage() {
-        return FALLBACK_STRING.equals(result.message.getContent());
-    }
-
     public static ClovaResponseDto defaultFallbackResponse() {
         return ClovaResponseDto.builder()
                 .status(defaultFallbackStatus())

--- a/src/main/java/site/radio/clova/dto/ClovaResponseDto.java
+++ b/src/main/java/site/radio/clova/dto/ClovaResponseDto.java
@@ -73,6 +73,10 @@ public class ClovaResponseDto {
         return result.message.getContent();
     }
 
+    public boolean hasFallbackMessage() {
+        return FALLBACK_STRING.equals(result.message.getContent());
+    }
+
     public static ClovaResponseDto defaultFallbackResponse() {
         return ClovaResponseDto.builder()
                 .status(defaultFallbackStatus())

--- a/src/main/java/site/radio/common/EventStatus.java
+++ b/src/main/java/site/radio/common/EventStatus.java
@@ -1,0 +1,14 @@
+package site.radio.common;
+
+public enum EventStatus {
+
+    // 기본 상태
+    PENDING,
+    PROCESSING,
+    COMPLETED,
+
+    // 롤백 상태
+    ROLLBACK_REQUIRED,
+    ROLLBACK_PROCESSING,
+    ROLLBACK_COMPLETED,
+}

--- a/src/main/java/site/radio/config/RedisConfig.java
+++ b/src/main/java/site/radio/config/RedisConfig.java
@@ -5,8 +5,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.data.redis.core.StringRedisTemplate;
 
 @Configuration
 public class RedisConfig {
@@ -23,17 +22,9 @@ public class RedisConfig {
     }
 
     @Bean
-    public RedisTemplate<String, String> redisTemplate() {
-        RedisTemplate<String, String> template = new RedisTemplate<>();
-
-        template.setConnectionFactory(redisConnectionFactory());
-
-        // K-V serialize
-        template.setKeySerializer(new StringRedisSerializer());
-        template.setValueSerializer(new StringRedisSerializer());
-
-        // default serialize
-        template.setDefaultSerializer(new StringRedisSerializer());
+    public StringRedisTemplate redisTemplate() {
+        StringRedisTemplate template = new StringRedisTemplate(redisConnectionFactory());
+        template.setEnableTransactionSupport(true);
 
         return template;
     }

--- a/src/main/java/site/radio/facade/LetterReplyEventListener.java
+++ b/src/main/java/site/radio/facade/LetterReplyEventListener.java
@@ -1,0 +1,46 @@
+package site.radio.facade;
+
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import site.radio.letter.Letter;
+import site.radio.letter.LetterCreationEvent;
+import site.radio.letter.LetterService;
+import site.radio.reply.ReplyResponseDto;
+import site.radio.reply.ReplyService;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class LetterReplyEventListener {
+
+    private final LetterService letterService;
+    private final ReplyService replyService;
+
+    @Transactional
+    @EventListener
+    public void handleCreationLetter(LetterCreationEvent event) {
+        // event status => PROCESSING
+        event.process();
+
+        // letter 저장
+        Letter letter = letterService.save(UUID.fromString(event.getUserId()),
+                event.getMessage(),
+                event.getPreference(),
+                event.isPublished());
+
+        // reply 저장
+        ReplyResponseDto replyResponse = replyService.save(letter, event.getTwoTypeMessage());
+
+        // future complete
+        if (!event.getFuture().complete(replyResponse)) {
+            log.warn("Failed to complete future for letter {}", letter.getId());
+        }
+
+        // event status => COMPLETE
+        event.complete();
+    }
+}

--- a/src/main/java/site/radio/facade/LetterReplyFacadeService.java
+++ b/src/main/java/site/radio/facade/LetterReplyFacadeService.java
@@ -34,12 +34,15 @@ public class LetterReplyFacadeService {
 
         // 외부 API 호출
         ClovaResponseDto clovaResponse = clovaService.send(letterRequestDto.getMessage());
-        if (clovaResponse.hasFallbackMessage()) {
-            // 외부 API 호출에 예외 발생 시 사용 횟수 롤백 이벤트 발행, event status => ROLLBACK_REQUIRED
+
+        TwoTypeMessage twoTypeMessage = null;
+        try {
+            twoTypeMessage = clovaService.extract(clovaResponse);
+        } catch (IllegalArgumentException e) {
             log.error("clova studio api 호출에 문제가 발생했습니다. userId: {}", letterRequestDto.getUserId());
             rateLimitService.rollback(letterRequestDto.getUserId());
         }
-        return clovaService.extract(clovaResponse);
+        return twoTypeMessage;
     }
 
     @Transactional

--- a/src/main/java/site/radio/facade/LetterReplyFacadeService.java
+++ b/src/main/java/site/radio/facade/LetterReplyFacadeService.java
@@ -1,0 +1,73 @@
+package site.radio.facade;
+
+import feign.FeignException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import site.radio.clova.dto.ClovaResponseDto;
+import site.radio.clova.letter.TwoTypeMessage;
+import site.radio.clova.service.ClovaService;
+import site.radio.error.RateLimitException;
+import site.radio.letter.LetterCreationEvent;
+import site.radio.letter.LetterRequestDto;
+import site.radio.limiter.RateLimitRollbackEvent;
+import site.radio.limiter.RateLimitService;
+import site.radio.reply.ReplyResponseDto;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class LetterReplyFacadeService {
+
+    private final RateLimitService rateLimitService;
+    private final ClovaService clovaService;
+    private final ApplicationEventPublisher eventPublisher;
+
+    public TwoTypeMessage sendLetterToClova(LetterRequestDto letterRequestDto) {
+        // 사용 횟수 선차감
+        if (!rateLimitService.preDeductUsage(letterRequestDto.getUserId())) {
+            throw new RateLimitException("요청 제한 횟수 초과");
+        }
+
+        try {
+            // 외부 API 호출
+            ClovaResponseDto clovaResponse = clovaService.send(letterRequestDto.getMessage());
+            return clovaService.extract(clovaResponse);
+        } catch (FeignException e) {
+            // 외부 API 호출에 예외 발생 시 사용 횟수 롤백 이벤트 발행, event status => ROLLBACK_REQUIRED
+            log.error("clova studio api 호출에 문제가 발생했습니다. userId: {}", letterRequestDto.getUserId());
+            eventPublisher.publishEvent(RateLimitRollbackEvent.createEvent(letterRequestDto.getUserId()));
+            throw e;
+        }
+    }
+
+    @Transactional
+    public ReplyResponseDto responseReply(LetterRequestDto letterRequestDto, TwoTypeMessage twoTypeMessage) {
+        CompletableFuture<ReplyResponseDto> future = new CompletableFuture<>();
+
+        // event status => PENDING
+        LetterCreationEvent event = LetterCreationEvent.createEvent(
+                letterRequestDto.getUserId(),
+                letterRequestDto.getMessage(),
+                letterRequestDto.getPreference(),
+                letterRequestDto.isPublished(),
+                twoTypeMessage,
+                future);
+
+        // 편지 생성 이벤트 발행
+        eventPublisher.publishEvent(event);
+
+        try {
+            // 편지부터 답장까지 생성이 완료되면 응답을 반환
+            return future.get(120, TimeUnit.SECONDS);
+        } catch (InterruptedException | ExecutionException | TimeoutException e) {
+            throw new RuntimeException("Failed future for reply response", e);
+        }
+    }
+}

--- a/src/main/java/site/radio/facade/LetterReplyFacadeService.java
+++ b/src/main/java/site/radio/facade/LetterReplyFacadeService.java
@@ -4,7 +4,6 @@ import feign.FeignException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import site.radio.clova.dto.ClovaResponseDto;
@@ -14,7 +13,6 @@ import site.radio.error.RateLimitException;
 import site.radio.letter.Letter;
 import site.radio.letter.LetterRequestDto;
 import site.radio.letter.LetterService;
-import site.radio.limiter.RateLimitRollbackEvent;
 import site.radio.limiter.RateLimitService;
 import site.radio.reply.ReplyResponseDto;
 import site.radio.reply.ReplyService;
@@ -28,7 +26,6 @@ public class LetterReplyFacadeService {
     private final ClovaService clovaService;
     private final LetterService letterService;
     private final ReplyService replyService;
-    private final ApplicationEventPublisher eventPublisher;
 
     public TwoTypeMessage sendLetterToClova(LetterRequestDto letterRequestDto) {
         // 사용 횟수 선차감
@@ -43,7 +40,7 @@ public class LetterReplyFacadeService {
         } catch (FeignException e) {
             // 외부 API 호출에 예외 발생 시 사용 횟수 롤백 이벤트 발행, event status => ROLLBACK_REQUIRED
             log.error("clova studio api 호출에 문제가 발생했습니다. userId: {}", letterRequestDto.getUserId());
-            eventPublisher.publishEvent(RateLimitRollbackEvent.createEvent(letterRequestDto.getUserId()));
+            rateLimitService.rollback(letterRequestDto.getUserId());
             throw e;
         }
     }

--- a/src/main/java/site/radio/letter/LetterController.java
+++ b/src/main/java/site/radio/letter/LetterController.java
@@ -1,7 +1,5 @@
 package site.radio.letter;
 
-import site.radio.reply.ReplyResponseDto;
-import site.radio.reply.ReplyService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -18,6 +16,9 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import site.radio.clova.letter.TwoTypeMessage;
+import site.radio.facade.LetterReplyFacadeService;
+import site.radio.reply.ReplyResponseDto;
 
 @Tag(name = "letter", description = "편지 API")
 @RestController
@@ -26,15 +27,15 @@ import org.springframework.web.bind.annotation.RestController;
 public class LetterController {
 
     private final LetterService letterService;
-    private final ReplyService replyService;
+    private final LetterReplyFacadeService letterReplyFacadeService;
 
     @Operation(summary = "유저의 사연이 담긴 편지를 접수받는 API", description = "유저의 편지로부터 CLOVA를 이용해 답장을 제공합니다.")
     @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.CREATED)
     public ReplyResponseDto receiveLetter(@Valid @RequestBody LetterRequestDto letterRequestDto) {
-        LetterResponseDto letterResponse = letterService.saveLetter(letterRequestDto);
+        TwoTypeMessage twoTypeMessage = letterReplyFacadeService.sendLetterToClova(letterRequestDto);
 
-        return replyService.makeAndSaveReply(letterResponse);
+        return letterReplyFacadeService.responseReply(letterRequestDto, twoTypeMessage);
     }
 
     @Operation(summary = "편지 삭제 요청 API", description = "요청한 편지 ID에 해당하는 편지를 제거합니다.")

--- a/src/main/java/site/radio/letter/LetterCreationEvent.java
+++ b/src/main/java/site/radio/letter/LetterCreationEvent.java
@@ -1,0 +1,39 @@
+package site.radio.letter;
+
+import java.util.concurrent.CompletableFuture;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import site.radio.clova.letter.TwoTypeMessage;
+import site.radio.common.EventStatus;
+import site.radio.reply.ReplyResponseDto;
+import site.radio.user.domain.Preference;
+
+@Getter
+@RequiredArgsConstructor
+public class LetterCreationEvent {
+
+    private final String userId;
+    private final String message;
+    private final Preference preference;
+    private final boolean published;
+    private final TwoTypeMessage twoTypeMessage;
+    private final CompletableFuture<ReplyResponseDto> future;
+    private EventStatus status = EventStatus.PENDING;
+
+    public static LetterCreationEvent createEvent(String userId,
+                                                  String message,
+                                                  Preference preference,
+                                                  boolean published,
+                                                  TwoTypeMessage twoTypeMessage,
+                                                  CompletableFuture<ReplyResponseDto> future) {
+        return new LetterCreationEvent(userId, message, preference, published, twoTypeMessage, future);
+    }
+
+    public void process() {
+        this.status = EventStatus.PROCESSING;
+    }
+
+    public void complete() {
+        this.status = EventStatus.COMPLETED;
+    }
+}

--- a/src/main/java/site/radio/limiter/RateLimitRollbackEvent.java
+++ b/src/main/java/site/radio/limiter/RateLimitRollbackEvent.java
@@ -1,0 +1,28 @@
+package site.radio.limiter;
+
+import lombok.Getter;
+import site.radio.common.EventStatus;
+
+@Getter
+public class RateLimitRollbackEvent {
+
+    private final String userId;
+    private EventStatus status;
+
+    public RateLimitRollbackEvent(String userId) {
+        this.userId = userId;
+        this.status = EventStatus.ROLLBACK_REQUIRED;
+    }
+
+    public static RateLimitRollbackEvent createEvent(String userId) {
+        return new RateLimitRollbackEvent(userId);
+    }
+
+    public void process() {
+        this.status = EventStatus.ROLLBACK_PROCESSING;
+    }
+
+    public void complete() {
+        this.status = EventStatus.ROLLBACK_COMPLETED;
+    }
+}

--- a/src/main/java/site/radio/limiter/RateLimitService.java
+++ b/src/main/java/site/radio/limiter/RateLimitService.java
@@ -72,16 +72,20 @@ public class RateLimitService {
 
     @Transactional
     @EventListener
-    public void rollback(RateLimitRollbackEvent event) {
+    public void handleRollbackEvent(RateLimitRollbackEvent event) {
         // event status => ROLLBACK_PROCESSING
         event.process();
 
-        String key = getKey(event.getUserId());
-        redisTemplate.opsForValue().decrement(key, 1);
-        log.info("사용 횟수가 롤백 되었습니다. userId: {}", event.getUserId());
+        rollback(event.getUserId());
 
         // event status => ROLLBACK_COMPLETE
         event.complete();
+    }
+
+    public void rollback(String userId) {
+        String key = getKey(userId);
+        redisTemplate.opsForValue().decrement(key, 1);
+        log.info("사용 횟수가 롤백 되었습니다. userId: {}", userId);
     }
 
     private String getKey(String userId) {

--- a/src/main/java/site/radio/limiter/RateLimitService.java
+++ b/src/main/java/site/radio/limiter/RateLimitService.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.event.EventListener;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
@@ -26,7 +27,7 @@ public class RateLimitService {
     @Value("${redis.expire}")
     private long BASIC_EXPIRE_TIME;
 
-    private final RedisTemplate<String, String> redisTemplate;
+    private final StringRedisTemplate redisTemplate;
 
     /**
      * 유저의 요청이 제한 횟수를 초과하는지 유저 아이디로 조회하는 메서드.

--- a/src/main/java/site/radio/reply/ReplyService.java
+++ b/src/main/java/site/radio/reply/ReplyService.java
@@ -1,14 +1,5 @@
 package site.radio.reply;
 
-import site.radio.clova.dto.ClovaResponseDto;
-import site.radio.clova.letter.TwoTypeMessage;
-import site.radio.clova.service.ClovaService;
-import site.radio.error.LetterNotFoundException;
-import site.radio.error.UserNotFoundException;
-import site.radio.letter.Letter;
-import site.radio.letter.LetterResponseDto;
-import site.radio.letter.LetterService;
-import site.radio.user.repository.UserRepository;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.Year;
@@ -23,6 +14,15 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import site.radio.clova.dto.ClovaResponseDto;
+import site.radio.clova.letter.TwoTypeMessage;
+import site.radio.clova.service.ClovaService;
+import site.radio.error.LetterNotFoundException;
+import site.radio.error.UserNotFoundException;
+import site.radio.letter.Letter;
+import site.radio.letter.LetterResponseDto;
+import site.radio.letter.LetterService;
+import site.radio.user.repository.UserRepository;
 
 @Service
 @Transactional
@@ -57,6 +57,18 @@ public class ReplyService {
                 .letter(letter)
                 .messageForF(twoTypeMessage.getMessageForF())
                 .messageForT(twoTypeMessage.getMessageForT())
+                .build();
+
+        Reply savedReply = replyRepository.save(reply);
+
+        return ReplyResponseDto.of(savedReply);
+    }
+
+    public ReplyResponseDto save(Letter letter, TwoTypeMessage twoTypeMessage) {
+        Reply reply = Reply.builder()
+                .letter(letter)
+                .messageForT(twoTypeMessage.getMessageForT())
+                .messageForF(twoTypeMessage.getMessageForF())
                 .build();
 
         Reply savedReply = replyRepository.save(reply);


### PR DESCRIPTION
처음에 MSA 도입을 위한 사전 준비로 Spring Event와 보상 트랜잭션으로 처리하려다  
모놀리식 구조에선 최선이 아닌 것 같아 로직 순서만 바꿔 해결했습니다.