### PR TITLE
Clova 요청 실패 시 Fallback처리 로직 개선

### DIFF
--- a/src/main/java/site/radio/clova/client/ClovaClientWithFallback.java
+++ b/src/main/java/site/radio/clova/client/ClovaClientWithFallback.java
@@ -1,16 +1,26 @@
 package site.radio.clova.client;
 
+import lombok.RequiredArgsConstructor;
 import site.radio.clova.dto.ClovaRequestDto;
 import site.radio.clova.dto.ClovaResponseDto;
 import lombok.extern.slf4j.Slf4j;
+import site.radio.error.ExternalApiFallbackException;
 
 @Slf4j
+@RequiredArgsConstructor
 public class ClovaClientWithFallback implements ClovaFeignClient {
+
+    private final Throwable cause;
 
     @Override
     public ClovaResponseDto sendToClova(String apiKey, String apigwKey, String requestId,
                                         ClovaRequestDto clovaRequestDto) {
         log.error("fallback occurred.");
+
+        if (cause instanceof ExternalApiFallbackException apiFallbackException) {
+            throw apiFallbackException;
+        }
+
         return ClovaResponseDto.defaultFallbackResponse();
     }
 }

--- a/src/main/java/site/radio/clova/client/ClovaFeignConfig.java
+++ b/src/main/java/site/radio/clova/client/ClovaFeignConfig.java
@@ -4,11 +4,16 @@ import feign.Response;
 import feign.codec.ErrorDecoder;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.util.StreamUtils;
+import site.radio.error.ExternalApiClientException;
+import site.radio.error.ExternalApiServerException;
 
 @Slf4j
 public class ClovaFeignConfig implements ErrorDecoder {
+
+    private final ErrorDecoder errorDecoder = new Default();
 
     @Override
     public Exception decode(String methodKey, Response response) {
@@ -23,11 +28,11 @@ public class ClovaFeignConfig implements ErrorDecoder {
 
         if (400 <= statusCode && statusCode < 500) {
             log.error("[Status: {}] UpUpRadio 서버 --> 클로바 서버 호출 실패 [Body: {}]", statusCode, stringBody);
-        }
-        if (500 <= statusCode) {
+            return new ExternalApiClientException("잘못된 클라이언트 요청으로 Clova 서버 호출에 실패했습니다.");
+        } else if (500 >= statusCode) {
             log.error("[Status: {}] 클로바 서버 오류 [Body: {}]", statusCode, stringBody);
+            return new ExternalApiServerException("Clova 서버 장애로 인해 요청을 처리할 수 없습니다.");
         }
-        ErrorDecoder errorDecoder = new Default();
         return errorDecoder.decode(methodKey, response);
     }
 

--- a/src/main/java/site/radio/clova/client/ClovaServiceFallbackFactory.java
+++ b/src/main/java/site/radio/clova/client/ClovaServiceFallbackFactory.java
@@ -12,6 +12,6 @@ public class ClovaServiceFallbackFactory implements FallbackFactory<ClovaFeignCl
     public ClovaFeignClient create(Throwable cause) {
         log.error("clova service fallback: ", cause);
         
-        return new ClovaClientWithFallback();
+        return new ClovaClientWithFallback(cause);
     }
 }

--- a/src/main/java/site/radio/common/RestApiControllerAdvice.java
+++ b/src/main/java/site/radio/common/RestApiControllerAdvice.java
@@ -16,6 +16,7 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 import site.radio.error.CustomErrorResponse;
 import site.radio.error.DormantUserLoginException;
 import site.radio.error.ExceptionType;
+import site.radio.error.ExternalApiFallbackException;
 import site.radio.error.ValidationErrorResponse;
 import site.radio.error.ValidationProblemDetails;
 
@@ -25,11 +26,13 @@ public class RestApiControllerAdvice extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<?> handleExceptions(Exception exception) {
+        log.error("An error occurred: ", exception);
         return createErrorResponse(exception);
     }
 
     @ExceptionHandler(DormantUserLoginException.class)
     public ResponseEntity<?> handleDormantUserLoginError(DormantUserLoginException exception) {
+        log.error("An error occurred: ", exception);
         return createErrorResponse(exception, exception.getMessage());
     }
 
@@ -37,6 +40,13 @@ public class RestApiControllerAdvice extends ResponseEntityExceptionHandler {
     public ResponseEntity<?> handleNoFallbackAvailableException(HttpServletRequest request,
                                                                 NoFallbackAvailableException exception) {
         log.warn("error occurred uri: {}, exception: ", request.getRequestURI(), exception.getCause());
+        return createErrorResponse(exception);
+    }
+
+    @ExceptionHandler(ExternalApiFallbackException.class)
+    public ResponseEntity<?> handleExternalApiFallbackException(HttpServletRequest request,
+                                                                ExternalApiFallbackException exception) {
+        log.error("error occurred uri: {}, exception: ", request.getRequestURI(), exception);
         return createErrorResponse(exception);
     }
 
@@ -71,8 +81,6 @@ public class RestApiControllerAdvice extends ResponseEntityExceptionHandler {
 
     private ResponseEntity<?> createErrorResponse(Exception exception, @Nullable String customMessage) {
         ExceptionType exceptionType = ExceptionType.from(exception);
-
-        log.error("An error occurred: {}", exceptionType.getException());
 
         // 메시지가 제공되면 사용, 없으면 기본 메시지로 처리
         String message = (customMessage != null) ? customMessage : exception.getMessage();

--- a/src/main/java/site/radio/common/resilience/DefaultExceptionRecordFailurePredicate.java
+++ b/src/main/java/site/radio/common/resilience/DefaultExceptionRecordFailurePredicate.java
@@ -23,6 +23,6 @@ public class DefaultExceptionRecordFailurePredicate implements Predicate<Throwab
             return true;
         }
 
-        return throwable instanceof FeignException.FeignServerException; // Fail 처리 (true)
+        return throwable instanceof FeignException; // Fail 처리 (true)
     }
 }

--- a/src/main/java/site/radio/error/ExceptionType.java
+++ b/src/main/java/site/radio/error/ExceptionType.java
@@ -6,6 +6,7 @@ import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.TOO_MANY_REQUESTS;
 import static org.springframework.http.HttpStatus.UNAUTHORIZED;
+import static org.springframework.http.HttpStatus.SERVICE_UNAVAILABLE;
 
 import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
 import jakarta.persistence.EntityNotFoundException;
@@ -23,6 +24,7 @@ public enum ExceptionType {
     // 400
     ILLEGAL_ARGUMENT_EXCEPTION(BAD_REQUEST, "error.illegal.argument", IllegalArgumentException.class),
     ARGS_INVALID_EXCEPTION(BAD_REQUEST, "error.args.invalid", MethodArgumentNotValidException.class),
+    EXTERNAL_API_CLIENT_EXCEPTION(BAD_REQUEST, "error.externalApi.client", ExternalApiClientException.class),
 
     // 401
     UNAUTHORIZED_EXCEPTION(UNAUTHORIZED, "error.unauthorized", BadCredentialsException.class),
@@ -41,9 +43,11 @@ public enum ExceptionType {
     // 500
     ILLEGAL_STATE_EXCEPTION(INTERNAL_SERVER_ERROR, "error.illegal.state", IllegalStateException.class),
     CALL_NOT_PERMITTED_EXCEPTION(INTERNAL_SERVER_ERROR, "error.call.notPermitted", CallNotPermittedException.class),
-    NO_FALLBACK_AVAILABLE_EXCEPTION(INTERNAL_SERVER_ERROR, "error.noFallbackAvailable",
-            NoFallbackAvailableException.class),
-    UNHANDLED_EXCEPTION(INTERNAL_SERVER_ERROR, "error.unhandled", Exception.class);   // default
+    NO_FALLBACK_AVAILABLE_EXCEPTION(INTERNAL_SERVER_ERROR, "error.noFallbackAvailable", NoFallbackAvailableException.class),
+    UNHANDLED_EXCEPTION(INTERNAL_SERVER_ERROR, "error.unhandled", Exception.class),   // default
+
+    // 503
+    EXTERNAL_API_SERVER_EXCEPTION(SERVICE_UNAVAILABLE, "error.externalApi.server", ExternalApiServerException.class);
 
     private final HttpStatus httpStatus;
     private final String messageKey;

--- a/src/main/java/site/radio/error/ExternalApiClientException.java
+++ b/src/main/java/site/radio/error/ExternalApiClientException.java
@@ -1,0 +1,7 @@
+package site.radio.error;
+
+public class ExternalApiClientException extends ExternalApiFallbackException {
+    public ExternalApiClientException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/site/radio/error/ExternalApiFallbackException.java
+++ b/src/main/java/site/radio/error/ExternalApiFallbackException.java
@@ -1,0 +1,7 @@
+package site.radio.error;
+
+public class ExternalApiFallbackException extends RuntimeException{
+    public ExternalApiFallbackException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/site/radio/error/ExternalApiServerException.java
+++ b/src/main/java/site/radio/error/ExternalApiServerException.java
@@ -1,0 +1,7 @@
+package site.radio.error;
+
+public class ExternalApiServerException extends ExternalApiFallbackException {
+    public ExternalApiServerException(String message) {
+        super(message);
+    }
+}

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -35,12 +35,10 @@ logging:
             bind: trace
 
 clova:
-  api:
-    key: none
-  apigw:
-    key: none
-  request:
-    id: none
+  secret:
+    api-key: none
+    apigw-key: none
+    request-id: none
 security:
   jwt:
     token:


### PR DESCRIPTION
### ErrorDecoder 커스터마이징 클래스 ClovaFeignConfig 수정
- 400번대 상태 코드는 `ExternalApiClientException`으로 변환하여 처리.
- 500번대 상태 코드는 `ExternalApiServerException`으로 변환하여 처리.
- 400대, 500대가 아닌 경우 기본 ErrorDecoder 동작 유지.

### FallbackFactory 개선
- Fallback 클래스에 발생한 예외를 그대로 전달해, 특정 예외 클래스(`ExternalApiFallbackException`)인 경우 재-throw하도록 구성.

### ExceptionHandler 추가
- `ExternalApiFallbackException` 처리하는 예외 핸들러 추가해, 어떤 uri에서 예외가 발생했는지 로그 출력하도록 구현

### ClovaFeignClient 테스트 코드 추가
- WireMock을 활용하여 Clova 서버 요청을 모킹하여 테스트
- 예외 처리 테스트
  - 400 상태 코드 응답 시 `ExternalApiClientException`이 발생하는지 확인.
  - 500 상태 코드 응답 시 `ExternalApiServerException`이 발생하는지 확인.